### PR TITLE
Add support for Python 3.7-3.11, drop EOL 2.7-3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         test-cmd: [pytest]
         include:
           #- python-version: pyp-y3.8
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         test-cmd: [pytest]
         include:
-          #- python-version: pypy3.5-5.8.0
+          #- python-version: pyp-y3.8
           #  test-cmd: pytest test_thefuzz.py test_thefuzz_pytest.py
-          - python-version: 3.6
+          - python-version: "3.7"
             test-cmd: python setup.py check --restructuredtext --strict --metadata
-          - python-version: 3.8
+          - python-version: "3.10"
             test-cmd: python setup.py check --restructuredtext --strict --metadata
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         test-cmd: [pytest]
         include:
           #- python-version: pyp-y3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     env: TEST_SUITE=pytest
   - python: "3.10"
     env: TEST_SUITE=pytest
+  - python: "3.11-dev"
+    env: TEST_SUITE=pytest
   - python: "pypy3.7-7.3.5"
     env: TEST_SUITE="pytest test_thefuzz.py test_thefuzz_pytest.py"
   - python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: python
 matrix:
   include:
-  - python: "2.7"
+  - python: "3.7"
     env: TEST_SUITE=pytest
-  - python: "3.4"
+  - python: "3.8"
     env: TEST_SUITE=pytest
-  - python: "3.5"
+  - python: "3.9"
     env: TEST_SUITE=pytest
-  - python: "3.6"
+  - python: "3.10"
     env: TEST_SUITE=pytest
-  - python: "pypy"
-    env: TEST_SUITE=pytest
-  - python: "pypy3.5-5.8.0"
+  - python: "pypy3.7-7.3.5"
     env: TEST_SUITE="pytest test_thefuzz.py test_thefuzz_pytest.py"
-  - python: 3.6
+  - python: "3.10"
     env: TEST_SUITE="python setup.py check --restructuredtext --strict --metadata"
 install:
   - pip install -U pip setuptools wheel
-  - pip install pytest==3.2.5 pycodestyle docutils Pygments hypothesis
+  - pip install pytest pycodestyle docutils Pygments hypothesis
 script:
   - $TEST_SUITE
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Fuzzy string matching like a boss. It uses `Levenshtein Distance <https://en.wik
 Requirements
 ============
 
--  Python 2.7 or higher
+-  Python 3.7 or higher
 -  difflib
 -  `python-Levenshtein <https://github.com/ztane/python-Levenshtein/>`_ (optional, provides a 4-10x speedup in String
    Matching, though may result in `differing results for certain cases <https://github.com/seatgeek/fuzzywuzzy/issues/128>`_)
@@ -47,7 +47,7 @@ Adding to your ``requirements.txt`` file (run ``pip install -r requirements.txt`
 .. code:: bash
 
     git+ssh://git@github.com/seatgeek/thefuzz.git@0.19.0#egg=thefuzz
-    
+
 Manually via GIT
 
 .. code:: bash
@@ -115,7 +115,7 @@ Process
 You can also pass additional parameters to ``extractOne`` method to make it use a specific scorer. A typical use case is to match file paths:
 
 .. code:: python
-  
+
     >>> process.extractOne("System of a down - Hypnotize - Heroin", songs)
         ('/music/library/good/System of a Down/2005 - Hypnotize/01 - Attack.mp3', 86)
     >>> process.extractOne("System of a down - Hypnotize - Heroin", songs, scorer=fuzz.token_sort_ratio)

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf8 -*-
-
 from timeit import timeit
 import math
 import csv
@@ -34,10 +32,10 @@ choices = [
 mixed_strings = [
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
     "C\\'est la vie",
-    u"Ça va?",
-    u"Cães danados",
-    u"\xacCamarões assados",
-    u"a\xac\u1234\u20ac\U00008000"
+    "Ça va?",
+    "Cães danados",
+    "\xacCamarões assados",
+    "a\xac\u1234\u20ac\U00008000"
 ]
 
 common_setup = "from thefuzz import fuzz, utils; "
@@ -53,7 +51,7 @@ def print_result_from_timeit(stmt='pass', setup='pass', number=1000000):
     avg_duration = duration / float(number)
     thousands = int(math.floor(math.log(avg_duration, 1000)))
 
-    print("Total time: %fs. Average run: %.3f%s." % (
+    print("Total time: {:f}s. Average run: {:.3f}{}.".format(
         duration, avg_duration * (1000 ** -thousands), units[-thousands]))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
     ],
     description='Fuzzy string matching in python',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # Copyright (c) 2014 SeatGeek
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ except ImportError:
 def open_file(fname):
     return open(os.path.join(os.path.dirname(__file__), fname))
 
+
 setup(
     name='thefuzz',
     version=__version__,
@@ -30,11 +31,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3 :: Only',
     ],
     description='Fuzzy string matching in python',
     long_description=open_file('README.rst').read(),

--- a/test_thefuzz.py
+++ b/test_thefuzz.py
@@ -171,9 +171,9 @@ class RatioTest(unittest.TestCase):
         s3 = "LSINJHUANG DISTRIC"
         s4 = "SINJHUANG DISTRICT"
 
-        self.assertTrue(fuzz.partial_ratio(s1, s2) > 75)
-        self.assertTrue(fuzz.partial_ratio(s1, s3) > 75)
-        self.assertTrue(fuzz.partial_ratio(s1, s4) > 75)
+        self.assertGreater(fuzz.partial_ratio(s1, s2), 75)
+        self.assertGreater(fuzz.partial_ratio(s1, s3), 75)
+        self.assertGreater(fuzz.partial_ratio(s1, s4), 75)
 
     def testRatioUnicodeString(self):
         s1 = "\u00C1"
@@ -420,9 +420,9 @@ class ProcessTest(unittest.TestCase):
         query = "new york mets vs chicago cubs"
         # Only find 100-score cases
         res = process.extractOne(query, choices, score_cutoff=100)
-        self.assertTrue(res is not None)
+        self.assertIsNotNone(res)
         best_match, score = res
-        self.assertTrue(best_match is choices[0])
+        self.assertIs(best_match, choices[0])
 
     def testEmptyStrings(self):
         choices = [
@@ -460,7 +460,7 @@ class ProcessTest(unittest.TestCase):
         search = 'aaa'
         result = [(value, confidence) for value, confidence in
                   process.extract(search, generate_choices())]
-        self.assertTrue(len(result) > 0)
+        self.assertGreater(len(result), 0)
 
     def test_dict_like_extract(self):
         """We should be able to use a dict-like object for choices, not only a
@@ -473,9 +473,9 @@ class ProcessTest(unittest.TestCase):
         choices = UserDict({'aa': 'bb', 'a1': None})
         search = 'aaa'
         result = process.extract(search, choices)
-        self.assertTrue(len(result) > 0)
+        self.assertGreater(len(result), 0)
         for value, confidence, key in result:
-            self.assertTrue(value in choices.values())
+            self.assertIn(value, choices.values())
 
     def test_dedupe(self):
         """We should be able to use a list-like object for contains_dupes
@@ -484,7 +484,7 @@ class ProcessTest(unittest.TestCase):
         contains_dupes = ['Frodo Baggins', 'Tom Sawyer', 'Bilbo Baggin', 'Samuel L. Jackson', 'F. Baggins', 'Frody Baggins', 'Bilbo Baggins']
 
         result = process.dedupe(contains_dupes)
-        self.assertTrue(len(result) < len(contains_dupes))
+        self.assertLess(len(result), len(contains_dupes))
 
         # Test 2
         contains_dupes = ['Tom', 'Dick', 'Harry']

--- a/test_thefuzz.py
+++ b/test_thefuzz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf8 -*-
-from __future__ import unicode_literals
 import unittest
 import re
 import sys
@@ -469,8 +467,7 @@ class ProcessTest(unittest.TestCase):
         """We should be able to use a list-like object for choices."""
         def generate_choices():
             choices = ['a', 'Bb', 'CcC']
-            for choice in choices:
-                yield choice
+            yield from choices
         search = 'aaa'
         result = [(value, confidence) for value, confidence in
                   process.extract(search, generate_choices())]

--- a/test_thefuzz.py
+++ b/test_thefuzz.py
@@ -1,15 +1,11 @@
 import unittest
 import re
-import sys
 import pycodestyle
 
 from thefuzz import fuzz
 from thefuzz import process
 from thefuzz import utils
 from thefuzz.string_processing import StringProcessor
-
-if sys.version_info[0] == 3:
-    unicode = str
 
 
 class StringProcessingTest(unittest.TestCase):
@@ -52,15 +48,9 @@ class UtilsTest(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_asciidammit(self):
+    def test_ascii_only(self):
         for s in self.mixed_strings:
-            utils.asciidammit(s)
-
-    def test_asciionly(self):
-        for s in self.mixed_strings:
-            # ascii only only runs on strings
-            s = utils.asciidammit(s)
-            utils.asciionly(s)
+            utils.ascii_only(s)
 
     def test_fullProcess(self):
         for s in self.mixed_strings:
@@ -165,11 +155,11 @@ class RatioTest(unittest.TestCase):
         # misordered full matches are scaled by .95
         self.assertEqual(fuzz.WRatio(self.s4, self.s5), 95)
 
-    def testWRatioUnicode(self):
-        self.assertEqual(fuzz.WRatio(unicode(self.s1), unicode(self.s1a)), 100)
+    def testWRatioStr(self):
+        self.assertEqual(fuzz.WRatio(str(self.s1), str(self.s1a)), 100)
 
-    def testQRatioUnicode(self):
-        self.assertEqual(fuzz.WRatio(unicode(self.s1), unicode(self.s1a)), 100)
+    def testQRatioStr(self):
+        self.assertEqual(fuzz.WRatio(str(self.s1), str(self.s1a)), 100)
 
     def testEmptyStringsScore100(self):
         self.assertEqual(fuzz.ratio("", ""), 100)
@@ -412,8 +402,7 @@ class ProcessTest(unittest.TestCase):
         # we don't want to randomly match to something, so we use a reasonable cutoff
 
         best = process.extractOne(query, choices, score_cutoff=50)
-        self.assertTrue(best is None)
-        # self.assertIsNone(best) # unittest.TestCase did not have assertIsNone until Python 2.7
+        self.assertIsNone(best)
 
         # however if we had no cutoff, something would get returned
 

--- a/thefuzz/StringMatcher.py
+++ b/thefuzz/StringMatcher.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 """
 StringMatcher.py
 

--- a/thefuzz/__init__.py
+++ b/thefuzz/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 __version__ = '0.19.0'

--- a/thefuzz/fuzz.py
+++ b/thefuzz/fuzz.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
-from __future__ import unicode_literals
 import platform
 import warnings
 
@@ -79,7 +77,7 @@ def _process_and_sort(s, force_ascii, full_process=True):
     tokens = ts.split()
 
     # sort tokens and join
-    sorted_string = u" ".join(sorted(tokens))
+    sorted_string = " ".join(sorted(tokens))
     return sorted_string.strip()
 
 

--- a/thefuzz/process.py
+++ b/thefuzz/process.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 from . import fuzz
 from . import utils
 import heapq
@@ -81,9 +80,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        _logger.warning(u"Applied processor reduces input query to empty string, "
+        _logger.warning("Applied processor reduces input query to empty string, "
                         "all comparisons will have score 0. "
-                        "[Query: \'{0}\']".format(query))
+                        f"[Query: \'{query}\']")
 
     # Don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,

--- a/thefuzz/string_processing.py
+++ b/thefuzz/string_processing.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import re
 import string
 import sys
@@ -8,7 +7,7 @@ if PY3:
     string = str
 
 
-class StringProcessor(object):
+class StringProcessor:
     """
     This class defines method to process strings in the most
     efficient way. Ideally all the methods below use unicode strings

--- a/thefuzz/string_processing.py
+++ b/thefuzz/string_processing.py
@@ -1,10 +1,4 @@
 import re
-import string
-import sys
-
-PY3 = sys.version_info[0] == 3
-if PY3:
-    string = str
 
 
 class StringProcessor:
@@ -23,7 +17,3 @@ class StringProcessor:
         numbers with a single white space.
         """
         return cls.regex.sub(" ", a_string)
-
-    strip = staticmethod(string.strip)
-    to_lower_case = staticmethod(string.lower)
-    to_upper_case = staticmethod(string.upper)

--- a/thefuzz/utils.py
+++ b/thefuzz/utils.py
@@ -1,10 +1,6 @@
-import sys
 import functools
 
 from thefuzz.string_processing import StringProcessor
-
-
-PY3 = sys.version_info[0] == 3
 
 
 def validate_string(s):
@@ -48,37 +44,20 @@ def check_empty_string(func):
 
 
 bad_chars = "".join([chr(i) for i in range(128, 256)])  # ascii dammit!
-if PY3:
-    translation_table = {ord(c): None for c in bad_chars}
-    unicode = str
+translation_table = {ord(c): None for c in bad_chars}
 
 
-def asciionly(s):
-    if PY3:
-        return s.translate(translation_table)
-    else:
-        return s.translate(None, bad_chars)
-
-
-def asciidammit(s):
-    if type(s) is str:
-        return asciionly(s)
-    elif type(s) is unicode:
-        return asciionly(s.encode('ascii', 'ignore'))
-    else:
-        return asciidammit(unicode(s))
+def ascii_only(s):
+    return s.translate(translation_table)
 
 
 def make_type_consistent(s1, s2):
-    """If both objects aren't either both string or unicode instances force them to unicode"""
+    """If objects aren't both string instances force them to strings"""
     if isinstance(s1, str) and isinstance(s2, str):
         return s1, s2
 
-    elif isinstance(s1, unicode) and isinstance(s2, unicode):
-        return s1, s2
-
     else:
-        return unicode(s1), unicode(s2)
+        return str(s1), str(s2)
 
 
 def full_process(s, force_ascii=False):
@@ -89,13 +68,11 @@ def full_process(s, force_ascii=False):
         if force_ascii == True, force convert to ascii"""
 
     if force_ascii:
-        s = asciidammit(s)
+        s = ascii_only(str(s))
     # Keep only Letters and Numbers (see Unicode docs).
     string_out = StringProcessor.replace_non_letters_non_numbers_with_whitespace(s)
-    # Force into lowercase.
-    string_out = StringProcessor.to_lower_case(string_out)
-    # Remove leading and trailing whitespaces.
-    string_out = StringProcessor.strip(string_out)
+    # Remove leading and trailing whitespaces and force into lowercase.
+    string_out = string_out.strip().lower()
     return string_out
 
 

--- a/thefuzz/utils.py
+++ b/thefuzz/utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import sys
 import functools
 
@@ -48,9 +47,9 @@ def check_empty_string(func):
     return decorator
 
 
-bad_chars = str("").join([chr(i) for i in range(128, 256)])  # ascii dammit!
+bad_chars = "".join([chr(i) for i in range(128, 256)])  # ascii dammit!
 if PY3:
-    translation_table = dict((ord(c), None) for c in bad_chars)
+    translation_table = {ord(c): None for c in bad_chars}
     unicode = str
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37, 38, 39, 310, py3}
+envlist = py{37, 38, 39, 310, 311, py3}
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3
+envlist = py{37, 38, 39, 310, py3}
 skip_missing_interpreters = True
 
 [testenv]
-deps = pytest==3.2.5
+deps = pytest
        pycodestyle
        hypothesis
 commands = pytest


### PR DESCRIPTION
Add support for newer Python 3.7-3.11.

Python 2.7-3.6 are EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-13 | 2020-09-13 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |

They're also little used.

Here's the pip installs for thefuzz from PyPI for March 2022:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.8      |  84.01% |   260,275 |
| 3.7      |   7.80% |    24,177 |
| null     |   4.06% |    12,579 |
| 3.9      |   2.60% |     8,051 |
| 3.6      |   0.82% |     2,532 |
| 3.10     |   0.65% |     2,017 |
| 3.5      |   0.06% |       179 |
| 2.7      |   0.01% |        20 |
| Total    |         |   309,830 |

Date range: 2022-03-01 - 2022-03-31

Source: `pip install -U pypistats && pypistats python_minor thefuzz --last-month`

Also upgrade to modern Python syntax with https://github.com/asottile/pyupgrade/ and unit tests with https://github.com/isidentical/teyit.

Sample build:

* https://github.com/hugovk/thefuzz/actions/runs/2082115423