### PR TITLE
Fix tests for module-scoped logger

### DIFF
--- a/test_thefuzz_pytest.py
+++ b/test_thefuzz_pytest.py
@@ -18,5 +18,5 @@ def test_process_warning(caplog):
     log = caplog.records[0]
 
     assert log.levelname == "WARNING"
-    assert log.name == "root"
+    assert log.name == "thefuzz.process"
     assert logstr == log.message


### PR DESCRIPTION
Fix to match changes made in https://github.com/seatgeek/thefuzz/pull/21.


```
test_thefuzz.py .................................................        [ 69%]
test_thefuzz_hypothesis.py .....................                         [ 98%]
test_thefuzz_pytest.py F                                                 [100%]

=================================== FAILURES ===================================
_____________________________ test_process_warning _____________________________

caplog = <_pytest.logging.LogCaptureFixture object at 0x7f9cab835070>

    def test_process_warning(caplog):
        """Check that a string reduced to 0 by processor logs a warning to stderr"""
    
        query = ':::::::'
        choices = [':::::::']
    
        _ = process.extractOne(query, choices)
    
        logstr = ("Applied processor reduces "
                  "input query to empty string, "
                  "all comparisons will have score 0. "
                  "[Query: ':::::::']")
    
        assert 1 == len(caplog.records)
        log = caplog.records[0]
    
        assert log.levelname == "WARNING"
>       assert log.name == "root"
E       AssertionError: assert 'thefuzz.process' == 'root'
E         - root
E         + thefuzz.process

test_thefuzz_pytest.py:[21](https://github.com/seatgeek/thefuzz/runs/6443070099?check_suite_focus=true#step:5:21): AssertionError
------------------------------ Captured log call -------------------------------
WARNING  thefuzz.process:process.py:84 Applied processor reduces input query to empty string, all comparisons will have score 0. [Query: ':::::::']
```

https://github.com/seatgeek/thefuzz/actions/runs/2328290584
