### PR TITLE
Include stubs and py.typed in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include *.txt
 include *.rst
 include test_thefuzz.py
+global-include py.typed
+global-include *.pyi

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     author='Adam Cohen',
     author_email='adam@seatgeek.com',
     packages=['thefuzz'],
+    include_package_data=True,
     # keep for backwards compatibility of projects depending on `thefuzz[speedup]`
     extras_require={'speedup': []},
     install_requires=['rapidfuzz>=3.0.0, < 4.0.0'],


### PR DESCRIPTION
Currently, the thefuzz distributions (wheel, tarball) don't include the
py.typed file or any of the .pyi stubs. This PR updates MANIFEST.in to make
sure these files are distributed too.
